### PR TITLE
Switch order of charts in Chart.tsx

### DIFF
--- a/src/pages/Chart.tsx
+++ b/src/pages/Chart.tsx
@@ -1,3 +1,4 @@
+
 import React from 'react';
 import Breadcrumb from '../components/Breadcrumbs/Breadcrumb';
 import ChartOne from '../components/Charts/ChartOne';
@@ -11,8 +12,8 @@ const Chart: React.FC = () => {
       <Breadcrumb pageName="Chart" />
 
       <div className="grid grid-cols-12 gap-4 md:gap-6 2xl:gap-7.5">
-        <ChartOne />
         <ChartTwo />
+        <ChartOne />
         <ChartThree />
       </div>
     </DefaultLayout>


### PR DESCRIPTION
This PR switches the order of ChartOne (revenue) and ChartTwo (weekly profit) in `Chart.tsx` as requested.